### PR TITLE
Support for PHP 5.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,6 @@
 		}
 	],
 	"require": {
-		"php": ">=5.3.3",
 		"doctrine/migrations": "dev-master#4256449",
 		"kdyby/console": "~2.3"
 	},

--- a/src/Zenify/DoctrineMigrations/DI/MigrationsExtension.php
+++ b/src/Zenify/DoctrineMigrations/DI/MigrationsExtension.php
@@ -20,7 +20,7 @@ class MigrationsExtension extends CompilerExtension
 		'dirs' => array('%appDir%/../migrations'),
 		'namespace' => 'Migrations',
 		'enabled' => FALSE
-    );
+	);
 
 
 	public function __construct()


### PR DESCRIPTION
This is a really great extension and I appreciate it very much. However, I need to use it in an environment that cannot be upgraded from PHP 5.3 (at least not in foreseeable future).

As both libraries required by this project support PHP 5.3 out-of-the-box and the only feature used from PHP 5.4 is shortened array syntax, I've replaced shortened syntax by older array() version and downgraded required PHP5.3 dependency to newest version required by kdyby/console.

Changes were tested at php 5.3.10-ubuntu3.13.

Would you please merge this into the next proper release?
