### PR TITLE
Overwriting default directory

### DIFF
--- a/src/DI/MigrationsExtension.php
+++ b/src/DI/MigrationsExtension.php
@@ -39,15 +39,16 @@ class MigrationsExtension extends CompilerExtension
 	public function loadConfiguration()
 	{
 		$config = $this->getConfig($this->defaults);
-		
+
 		if ($config['enabled'] === FALSE) {
 			return;
 		}
-		
+
 		if(count($config['dirs']) > 1) {
-			unset($config['dirs'][0]);
+			$default = array_shift($config['dirs']);
+			$config['dirs'][] = $default;
 		}
-		
+
 		$this->validateConfigTypes($config);
 
 		$builder = $this->getContainerBuilder();


### PR DESCRIPTION
There was no way to overwrite default migrations directory, so I decided to this solution.
