### PR TITLE
Fixed default directory resolution

### DIFF
--- a/src/DI/MigrationsExtension.php
+++ b/src/DI/MigrationsExtension.php
@@ -46,11 +46,11 @@ class MigrationsExtension extends CompilerExtension
 		}
 		$this->validateConfigTypes($config);
 
-		if (count($config['dirs']) === 0) {
-			$config['dirs'] = ['%appDir%/../migrations'];
-		}
-
 		$builder = $this->getContainerBuilder();
+
+		if (count($config['dirs']) === 0) {
+			$config['dirs'] = [$builder->expand('%appDir%/../migrations')];
+		}
 
 		$builder->addDefinition($this->prefix('consoleOutput'))
 			->setClass(OutputWriter::class);


### PR DESCRIPTION
The default migrations directory was passed as a raw, unexpanded value, resulting in an `InvalidArgumentException` saying "Migrations directory "%appDir%/../migrations" does not exist."