### PR TITLE
Added support for PHP 5.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
 		{ "name": "Tomáš Votruba", "homepage": "http://tomasvotruba.cz" }
 	],
 	"require": {
-		"php": ">=5.5",
+		"php": ">=5.4",
 		"doctrine/migrations": "~1.0@dev",
 		"kdyby/doctrine": "~2.0",
 		"kdyby/console": "~2.0",

--- a/src/DI/MigrationsExtension.php
+++ b/src/DI/MigrationsExtension.php
@@ -11,8 +11,6 @@ use Kdyby\Console\DI\ConsoleExtension;
 use Nette\DI\CompilerExtension;
 use Nette\Utils\AssertionException;
 use Nette\Utils\Validators;
-use Zenify\DoctrineMigrations\Configuration\Configuration;
-use Zenify\DoctrineMigrations\OutputWriter;
 
 
 class MigrationsExtension extends CompilerExtension
@@ -23,13 +21,13 @@ class MigrationsExtension extends CompilerExtension
 	/**
 	 * @var array
 	 */
-	private $defaults = [
+	private $defaults = array(
 		'table' => 'doctrine_migrations',
-		'dirs' => [],
+		'dirs' => array(),
 		'namespace' => 'Migrations',
 		'enabled' => FALSE,
 		'codingStandard' => self::CS_TABS # or "spaces"
-	];
+	);
 
 
 	public function __construct()
@@ -49,29 +47,29 @@ class MigrationsExtension extends CompilerExtension
 		$builder = $this->getContainerBuilder();
 
 		if (count($config['dirs']) === 0) {
-			$config['dirs'] = [$builder->expand('%appDir%/../migrations')];
+			$config['dirs'] = array($builder->expand('%appDir%/../migrations'));
 		}
 
 		$builder->addDefinition($this->prefix('consoleOutput'))
-			->setClass(OutputWriter::class);
+			->setClass('Zenify\DoctrineMigrations\OutputWriter');
 
 		$configuration = $builder->addDefinition($this->prefix('configuration'))
-			->setClass(Configuration::class)
-			->addSetup('setMigrationsTableName', [$config['table']])
-			->addSetup('setMigrationsDirectory', [reset($config['dirs'])])
-			->addSetup('setMigrationsNamespace', [$config['namespace']])
-			->addSetup('setCs', [$config['codingStandard']]);
+			->setClass('Zenify\DoctrineMigrations\Configuration\Configuration')
+			->addSetup('setMigrationsTableName', array($config['table']))
+			->addSetup('setMigrationsDirectory', array(reset($config['dirs'])))
+			->addSetup('setMigrationsNamespace', array($config['namespace']))
+			->addSetup('setCs', array($config['codingStandard']));
 
 		$dirs = array_unique($config['dirs']);
 		foreach ($dirs as $dir) {
-			$configuration->addSetup('registerMigrationsFromDirectory', [$dir]);
+			$configuration->addSetup('registerMigrationsFromDirectory', array($dir));
 		}
 
 		foreach ($this->loadFromFile(__DIR__ . '/commands.neon') as $i => $class) {
 			$builder->addDefinition($this->prefix('command.' . $i))
 				->setClass($class)
 				->addTag(ConsoleExtension::COMMAND_TAG)
-				->addSetup('setMigrationConfiguration', [$configuration]);
+				->addSetup('setMigrationConfiguration', array($configuration));
 		}
 	}
 

--- a/tests/DI/MigrationsExtensionTest.php
+++ b/tests/DI/MigrationsExtensionTest.php
@@ -4,9 +4,6 @@ namespace ZenifyTests\DoctrineMigrations\DI;
 
 use Nette;
 use PHPUnit_Framework_TestCase;
-use Zenify;
-use Zenify\DoctrineMigrations\Configuration\Configuration;
-use Zenify\DoctrineMigrations\OutputWriter;
 use Zenify\DoctrineMigrations\Tests\ContainerFactory;
 
 
@@ -28,13 +25,13 @@ class MigrationsExtensionTest extends PHPUnit_Framework_TestCase
 	public function testExtension()
 	{
 		$this->assertInstanceOf(
-			Configuration::class,
-			$this->container->getByType(Configuration::class)
+			'Zenify\DoctrineMigrations\Configuration\Configuration',
+			$this->container->getByType('Zenify\DoctrineMigrations\Configuration\Configuration')
 		);
 
 		$this->assertInstanceOf(
-			OutputWriter::class,
-			$this->container->getByType(OutputWriter::class)
+			'Zenify\DoctrineMigrations\OutputWriter',
+			$this->container->getByType('Zenify\DoctrineMigrations\OutputWriter')
 		);
 	}
 


### PR DESCRIPTION
Hi to everybody.

I've replaced all PHP 5.5 features such as [] and ::class with their alternatives, so now can be this awesome extension used under PHP 5.4 too.

I've really needed this, because my server is hosting several sites which requires PHP 5.4, so I can't update it to newer version. :(
