### PR TITLE
Relax dependencies on Kdyby and allow install newer versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,11 +8,15 @@
 	"require": {
 		"php": ">=5.5",
 		"doctrine/migrations": "~1.0@dev",
-		"kdyby/doctrine": "~2.0",
-		"kdyby/console": "~2.0",
 		"tracy/tracy": "~2.2"
 	},
+	"suggest": {
+		"kdyby/doctrine": "Integration of Doctrine 2 ORM into Nette Framework",
+		"kdyby/console": "Integration of Symfony Console component into Nette Framework"
+	},
 	"require-dev": {
+		"kdyby/doctrine": ">=2.0@dev",
+		"kdyby/console": ">=2.0@dev",
 		"nette/bootstrap": "~2.2",
 		"nette/di": "~2.2",
 		"nette/http": "~2.2",


### PR DESCRIPTION
I haven't found any direct dependency on Kdyby, so I suppose it can be relaxed

```
$ composer update
Loading composer repositories with package information
Updating dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Installation request for zenify/doctrine-migrations ~2.1 -> satisfiable by zenify/doctrine-migrations[v2.1.0].
    - Can only install one of: kdyby/doctrine[2.0.x-dev, 3.0.x-dev].
    - Can only install one of: kdyby/doctrine[2.0.x-dev, 3.0.x-dev].
    - zenify/doctrine-migrations v2.1.0 requires kdyby/doctrine ~2.0 -> satisfiable by kdyby/doctrine[2.3.x-dev, 2.0.x-dev].
    - Conclusion: don't install kdyby/doctrine 2.3.x-dev
    - Installation request for kdyby/doctrine ~3.0@dev -> satisfiable by kdyby/doctrine[3.0.x-dev].
```
