### PR TITLE
ChangeCodingStandardEventSubscriber: fixed type error

### DIFF
--- a/src/EventSubscriber/ChangeCodingStandardEventSubscriber.php
+++ b/src/EventSubscriber/ChangeCodingStandardEventSubscriber.php
@@ -70,7 +70,7 @@ final class ChangeCodingStandardEventSubscriber implements EventSubscriberInterf
 
 		$i = 0;
 		while ( ! file_exists($this->getMigrationFileByVersion($version)) && $i <= 10) {
-			$version--;
+			$version = (string) --$version;
 			$i++;
 		}
 


### PR DESCRIPTION
Before the while loop, the variable `$version` is string. But inside the loop with `$version--` it becomes an integer, which leads to

```
TypeError

Argument 1 passed to Zenify\DoctrineMigrations\EventSubscriber\ChangeCodingStandardEventSubscriber::getMigrationFileByVersion() must be of the type string, integer given
```

I didn't change it to integer since string is more general...